### PR TITLE
Removed Unnecessary 

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -2,7 +2,7 @@ var express = require('express');
 var morgan = require('morgan');
 var bodyParser = require('body-parser');
 var cors = require('cors');
-var stripe = require('stripe')("sk_test_BQokikJOvBiI2HlWgH4olfQ2");
+var stripe = require('stripe')(process.env.StripeTestSecretKey);
 
 var PORT = process.env.PORT || 3000;
 

--- a/api/app.js
+++ b/api/app.js
@@ -2,6 +2,7 @@ var express = require('express');
 var morgan = require('morgan');
 var bodyParser = require('body-parser');
 var cors = require('cors');
+// var stripe = require('stripe')("sk_test_BQokikJOvBiI2HlWgH4olfQ2");
 var stripe = require('stripe')(process.env.StripeTestSecretKey);
 
 var PORT = process.env.PORT || 3000;

--- a/api/app.js
+++ b/api/app.js
@@ -2,8 +2,7 @@ var express = require('express');
 var morgan = require('morgan');
 var bodyParser = require('body-parser');
 var cors = require('cors');
-// var stripe = require('stripe')("sk_test_BQokikJOvBiI2HlWgH4olfQ2");
-var stripe = require('stripe')(process.env.StripeTestSecretKey);
+var stripe = require('stripe')("sk_test_BQokikJOvBiI2HlWgH4olfQ2");
 
 var PORT = process.env.PORT || 3000;
 

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -2,6 +2,5 @@ angular
   .module('angularStripe', [])
   .constant('API_URL', 'http://localhost:3000')
   .config(function() {
-    // Stripe.setPublishableKey('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
-    Stripe.setPublishableKey('pk_test_hH5Fe3p7JU0r88Hklk3Y6J7m');
+    Stripe.setPublishableKey('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
   });

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -2,5 +2,6 @@ angular
   .module('angularStripe', [])
   .constant('API_URL', 'http://localhost:3000')
   .config(function() {
+    // Stripe.setPublishableKey('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
     Stripe.setPublishableKey('pk_test_hH5Fe3p7JU0r88Hklk3Y6J7m');
   });

--- a/frontend/js/app.js
+++ b/frontend/js/app.js
@@ -2,5 +2,5 @@ angular
   .module('angularStripe', [])
   .constant('API_URL', 'http://localhost:3000')
   .config(function() {
-    Stripe.setPublishableKey('pk_test_6pRNASCoBOKtIshFeQd4XMUh');
+    Stripe.setPublishableKey('pk_test_hH5Fe3p7JU0r88Hklk3Y6J7m');
   });

--- a/frontend/js/controllers/paymentController.js
+++ b/frontend/js/controllers/paymentController.js
@@ -16,7 +16,6 @@ function PaymentController($http, API_URL) {
     Stripe.card.createToken(self.card, function(status, response) {
       if(status === 200) {
         var data = {
-          card: self.card,
           token: response.id,
           amount: self.amount,
           currency: self.currency,

--- a/frontend/js/controllers/paymentController.js
+++ b/frontend/js/controllers/paymentController.js
@@ -18,8 +18,7 @@ function PaymentController($http, API_URL) {
         var data = {
           token: response.id,
           amount: self.amount,
-          currency: self.currency,
-          payee: self.payee
+          currency: self.currency
         };
 
         $http


### PR DESCRIPTION
The self.card does not need to be sent again in data object when doing the http request. It is already inside the token from Stripe.card.createToken(self.card).
The api does not accept a payee name to make the payment. So it is not needed for the name to be sent with the http request.
